### PR TITLE
Time reset when opening another document

### DIFF
--- a/discord_rpc/discord_rpc.py
+++ b/discord_rpc/discord_rpc.py
@@ -15,6 +15,7 @@ class DiscordRpc(Extension):
     def __init__(self, parent):
         super().__init__(parent)
         self.file = ""
+        self.time = 0
         self.timer = PyQt5.QtCore.QTimer(self)
         self.timer.setInterval(1000)
         self.timer.timeout.connect(self.update_rpc)
@@ -26,14 +27,17 @@ class DiscordRpc(Extension):
     def update_rpc(self):
         # Detecting new document
         if Krita.instance().activeDocument() is not None:
+            if self.time is not 0:
+                self.time = time.time()
             if self.file != Krita.instance().activeDocument().fileName():
-                RPC.update(details="Draws something cool",
-                           state=str(Krita.instance().activeDocument().name()) or "No name",
-                           large_image="krita_logo", start=int(time.time()))
+                RPC.update(details="Drawing something cool",
+                           state=str(Krita.instance().activeDocument().name()) or "Unnamed",
+                           large_image="krita_logo", start=int(self.time))
                 self.file = Krita.instance().activeDocument().fileName()
         else:
             RPC.update(details="Idle", large_image="krita_logo")
             self.file = ""
+            self.time = 0
 
     # This is C methods so can't rename
     # noinspection PyPep8Naming

--- a/discord_rpc/discord_rpc.py
+++ b/discord_rpc/discord_rpc.py
@@ -39,17 +39,9 @@ class DiscordRpc(Extension):
             self.file = ""
             self.time = 0
 
-    # This is C methods so can't rename
-    # noinspection PyPep8Naming
-    def createActions(self, window):
-        pass
-
     # noinspection PyPep8Naming
     def windowClosed(self):
         self.timer.stop()
-        pass
-
-    def action_triggered(self):
         pass
 
 

--- a/discord_rpc/discord_rpc.py
+++ b/discord_rpc/discord_rpc.py
@@ -40,6 +40,10 @@ class DiscordRpc(Extension):
             self.time = 0
 
     # noinspection PyPep8Naming
+    def createActions(self, window):
+        pass
+            
+    # noinspection PyPep8Naming
     def windowClosed(self):
         self.timer.stop()
         pass

--- a/discord_rpc/discord_rpc.py
+++ b/discord_rpc/discord_rpc.py
@@ -27,7 +27,7 @@ class DiscordRpc(Extension):
     def update_rpc(self):
         # Detecting new document
         if Krita.instance().activeDocument() is not None:
-            if self.time is not 0:
+            if self.time is 0:
                 self.time = time.time()
             if self.file != Krita.instance().activeDocument().fileName():
                 RPC.update(details="Drawing something cool",


### PR DESCRIPTION
If you open two or more documents and then change active document once or more, you'll see the RPC time wrong. This PR fixes it.
Internally done with time variable (class field) provided to RPC, which resets every time there are no opened documents.
- Don't reset time when changing active document
- Some language corrections (Draws something cool -> Drawing something cool, No name -> Unnamed)
- Removed one redudant method

I think there should be no bugs, at least it's working properly on my machine.