### PR TITLE
Document creation doesn't lead to change of RPC information

### DIFF
--- a/discord_rpc/discord_rpc.py
+++ b/discord_rpc/discord_rpc.py
@@ -14,7 +14,7 @@ RPC = Presence(DISCORD_RPC_CLIENT_ID)  # Initialize the client class
 class DiscordRpc(Extension):
     def __init__(self, parent):
         super().__init__(parent)
-        self.file = ""
+        self.file = None
         self.time = 0
         self.timer = PyQt5.QtCore.QTimer(self)
         self.timer.setInterval(1000)
@@ -36,7 +36,7 @@ class DiscordRpc(Extension):
                 self.file = Krita.instance().activeDocument().fileName()
         else:
             RPC.update(details="Idle", large_image="krita_logo")
-            self.file = ""
+            self.file = None
             self.time = 0
 
     # noinspection PyPep8Naming


### PR DESCRIPTION
Fixed: 
* When user creates new document, RPC is not updated and still displaying "Idle". 
Now it's updated and displaying "Unnamed" as a filename.

This PR should not produce any (new) bugs because this is just change of default field value. I tested it by one or two minutes just in case.