### PR TITLE
Added support for Qt6 and newer Python

### DIFF
--- a/discord_rpc/baseclient.py
+++ b/discord_rpc/baseclient.py
@@ -1,10 +1,8 @@
 import asyncio
 import inspect
 import json
-import os
 import struct
 import sys
-import tempfile
 from typing import Union, Optional
 
 # TODO: Get rid of this import * lol
@@ -102,22 +100,31 @@ class BaseClient:
                 len(payload)) +
             payload.encode('utf-8'))
 
-    async def handshake(self):
-        if sys.platform == 'linux' or sys.platform == 'darwin':
-            self.sock_reader, self.sock_writer = await asyncio.open_unix_connection(self.ipc_path)
-        elif sys.platform == 'win32' or sys.platform == 'win64':
-            self.sock_reader = asyncio.StreamReader(loop=self.loop)
-            reader_protocol = asyncio.StreamReaderProtocol(
-                self.sock_reader, loop=self.loop)
-            try:
-                self.sock_writer, _ = await self.loop.create_pipe_connection(lambda: reader_protocol, self.ipc_path)
-            except FileNotFoundError:
-                raise InvalidPipe
-        self.send_data(0, {'v': 1, 'client_id': self.client_id})
-        preamble = await self.sock_reader.read(8)
-        code, length = struct.unpack('<ii', preamble)
-        data = json.loads(await self.sock_reader.read(length))
-        if 'code' in data:
-            raise DiscordError(data['code'], data['message'])
-        if self._events_on:
-            self.sock_reader.feed_data = self.on_event
+    async def handshake(self, timeout=5):
+        try:
+            if sys.platform == 'linux' or sys.platform == 'darwin':
+                self.sock_reader, self.sock_writer = await asyncio.wait_for(
+                    asyncio.open_unix_connection(self.ipc_path),
+                    timeout=timeout
+                )
+            elif sys.platform == 'win32' or sys.platform == 'win64':
+                self.sock_reader = asyncio.StreamReader(loop=self.loop)
+                reader_protocol = asyncio.StreamReaderProtocol(
+                    self.sock_reader, loop=self.loop)
+                try:
+                    self.sock_writer, _ = await asyncio.wait_for(
+                        self.loop.create_pipe_connection(lambda: reader_protocol, self.ipc_path),
+                        timeout=timeout
+                    )
+                except FileNotFoundError:
+                    raise InvalidPipe
+            self.send_data(0, {'v': 1, 'client_id': self.client_id})
+            preamble = await asyncio.wait_for(self.sock_reader.read(8), timeout=timeout)
+            code, length = struct.unpack('<ii', preamble)
+            data = json.loads(await asyncio.wait_for(self.sock_reader.read(length), timeout=timeout))
+            if 'code' in data:
+                raise DiscordError(data['code'], data['message'])
+            if self._events_on:
+                self.sock_reader.feed_data = self.on_event
+        except asyncio.TimeoutError:
+            raise PyPresenceException('Connection to Discord timed out (timeout={0}s)'.format(timeout))

--- a/discord_rpc/discord_rpc.py
+++ b/discord_rpc/discord_rpc.py
@@ -1,9 +1,20 @@
 # Extension by Fistbobr
 
-from krita import Extension
+from krita import Extension, Krita
 from .presence import Presence
 import time
-import PyQt5.QtCore
+import asyncio
+
+try:
+    asyncio.get_event_loop()
+except RuntimeError:
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+try:
+    from PyQt6.QtCore import QTimer
+except ImportError:
+    from PyQt5.QtCore import QTimer
 
 DISCORD_RPC_CLIENT_ID = '744403269237080127'  # '541005130749968405'  # App ID. Change if you want
 EXTENSION_ID = 'pykrita_discord_rpc'
@@ -16,10 +27,11 @@ class DiscordRpc(Extension):
         super().__init__(parent)
         self.file = None
         self.time = 0
-        self.timer = PyQt5.QtCore.QTimer(self)
+        self.timer = QTimer(self)
         self.timer.setInterval(1000)
         self.timer.timeout.connect(self.update_rpc)
-        self.version = f"Krita {str(app.version())}";
+
+        self.version = f"Krita {str(Krita.instance().version())}"
 
     def setup(self):
         RPC.connect()  # Start the handshake loop
@@ -28,23 +40,35 @@ class DiscordRpc(Extension):
     def update_rpc(self):
         # Detecting new document
         try:
-            if Krita.instance().activeDocument() is not None:
-                if self.time is 0:
+            doc = Krita.instance().activeDocument()
+
+            if doc is not None:
+                if self.time == 0:
                     self.time = time.time()
-                if self.file != Krita.instance().activeDocument().fileName():
-                    RPC.update(details="Drawing something cool!",
-                               state=str(Krita.instance().activeDocument().name()) or "Unnamed",
-                               large_image="krita_logo", 
-                               start=int(self.time),
-                               large_text=self.version )
-                    
-                    self.file = Krita.instance().activeDocument().fileName()
+
+                filename = doc.fileName() or ""
+
+                if self.file != filename:
+                    RPC.update(
+                        details="Drawing something cool!",
+                        state=str(doc.name()) or "Unnamed",
+                        large_image="krita_logo",
+                        start=int(self.time),
+                        large_text=self.version
+                    )
+
+                    self.file = filename
+
             else:
-                RPC.update(details="Idle", large_image="krita_logo", large_text=self.version)
+                RPC.update(
+                    details="Idle",
+                    large_image="krita_logo",
+                    large_text=self.version
+                )
                 self.file = None
                 self.time = 0
-        except:
-            pass
+        except Exception as e:
+            print("RPC update error:", e)
 
     # noinspection PyPep8Naming
     def createActions(self, window):

--- a/discord_rpc/discord_rpc.py
+++ b/discord_rpc/discord_rpc.py
@@ -18,7 +18,7 @@ except ImportError:
 
 DISCORD_RPC_CLIENT_ID = '744403269237080127'  # '541005130749968405'  # App ID. Change if you want
 EXTENSION_ID = 'pykrita_discord_rpc'
-
+RECONNECT_INTERVAL = 30  # Try to reconnect every 30 seconds if offline
 
 RPC = Presence(DISCORD_RPC_CLIENT_ID)  # Initialize the client class
 
@@ -30,12 +30,22 @@ class DiscordRpc(Extension):
         self.timer = QTimer(self)
         self.timer.setInterval(1000)
         self.timer.timeout.connect(self.update_rpc)
+        
+        self.reconnect_timer = QTimer(self)
+        self.reconnect_timer.setInterval(RECONNECT_INTERVAL * 1000)
+        self.reconnect_timer.timeout.connect(self.try_reconnect)
 
         self.version = f"Krita {str(Krita.instance().version())}"
 
     def setup(self):
-        RPC.connect()  # Start the handshake loop
+        RPC.connect()
         self.timer.start()
+        self.reconnect_timer.start()
+    
+    def try_reconnect(self):
+        if not RPC.connected:
+            print('Retrying connection...')
+            RPC.reconnect()
 
     def update_rpc(self):
         # Detecting new document
@@ -77,6 +87,7 @@ class DiscordRpc(Extension):
     # noinspection PyPep8Naming
     def windowClosed(self):
         self.timer.stop()
+        self.reconnect_timer.stop()
         pass
 
 

--- a/discord_rpc/presence.py
+++ b/discord_rpc/presence.py
@@ -1,16 +1,19 @@
-import json
 import os
-import time
+import threading
+from typing import Optional
 
 from .baseclient import BaseClient
 from .payloads import Payload
 from .utils import remove_none, get_event_loop
+from .exceptions import PyPresenceException
 
 
 class Presence(BaseClient):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.connected = False
+        self._connection_thread: Optional[threading.Thread] = None
 
     def update(self, pid: int = os.getpid(),
                state: str = None, details: str = None,
@@ -23,26 +26,60 @@ class Presence(BaseClient):
                instance: bool = True,
                _donotuse=True):
 
-        if _donotuse is True:
-            payload = Payload.set_activity(pid=pid, state=state, details=details, start=start, end=end,
-                                           large_image=large_image, large_text=large_text,
-                                           small_image=small_image, small_text=small_text, party_id=party_id,
-                                           party_size=party_size, join=join, spectate=spectate,
-                                           match=match, buttons=buttons, instance=instance, activity=True)
+        if not self.connected:
+            return None  # Silently skip update if not connected, maybe add a warning? idk
+        
+        try:
+            if _donotuse is True:
+                payload = Payload.set_activity(pid=pid, state=state, details=details, start=start, end=end,
+                                               large_image=large_image, large_text=large_text,
+                                               small_image=small_image, small_text=small_text, party_id=party_id,
+                                               party_size=party_size, join=join, spectate=spectate,
+                                               match=match, buttons=buttons, instance=instance, activity=True)
 
-        else:
-            payload = _donotuse
-        self.send_data(1, payload)
-        return self.loop.run_until_complete(self.read_output())
+            else:
+                payload = _donotuse
+            self.send_data(1, payload)
+            return self.loop.run_until_complete(self.read_output())
+        except Exception as e:
+            print(f'Update failed: {e}')
+            self.connected = False
+            return None
 
     def clear(self, pid: int = os.getpid()):
-        payload = Payload.set_activity(pid, activity=None)
-        self.send_data(1, payload)
-        return self.loop.run_until_complete(self.read_output())
+        if not self.connected:
+            return None
+        
+        try:
+            payload = Payload.set_activity(pid, activity=None)
+            self.send_data(1, payload)
+            return self.loop.run_until_complete(self.read_output())
+        except Exception as e:
+            print(f'Clear failed: {e}')
+            self.connected = False
+            return None
 
-    def connect(self):
-        self.update_event_loop(get_event_loop())
-        self.loop.run_until_complete(self.handshake())
+    def connect(self, timeout=5):
+        def _connect():
+            try:
+                self.update_event_loop(get_event_loop())
+                self.loop.run_until_complete(self.handshake(timeout=timeout))
+                self.connected = True
+                print('Connected to Discord')
+            except PyPresenceException as e:
+                print(f'Connection failed: {e}')
+                self.connected = False
+            except Exception as e:
+                print(f'Unexpected connection error: {e}')
+                self.connected = False
+        
+        # Run connection in a separate thread to avoid blocking
+        self._connection_thread = threading.Thread(target=_connect, daemon=True)
+        self._connection_thread.start()
+    
+    def reconnect(self, timeout=5):
+        print('Attempting to reconnect to Discord...')
+        self.connect(timeout=timeout)
 
     def close(self):
         self.send_data(2, {'v': 1, 'client_id': self.client_id})


### PR DESCRIPTION
Tested on Krita 6.0.0 and 5.2.16 (for backwards compatibility testing)
What I've changed:
1. Importing just QTimer so instead of like
```py
import PyQt5.QtCore
self.timer = PyQt5.QtCore.QTimer(self)
```
it would be this, basically defaulting to Qt6 and if not fallback to Qt5
```py
try:
    from PyQt6.QtCore import QTimer
except ImportError:
    from PyQt5.QtCore import QTimer
```
2. Added this code at the beginning
```py
import asyncio

try:
    asyncio.get_event_loop()
except RuntimeError:
    loop = asyncio.new_event_loop()
    asyncio.set_event_loop(loop)
```
Which will error out `krita.scripting: "RuntimeError: There is no current event loop in thread 'MainThread'."` if not included, so gotta create a new one before doing anything with loops which is called in `utils.py` according to the stack trace

3. Using `Krita.instance()` instead of `app`, I remember encountering a bug of this but I don't know if it still exist? Keeping it here just in case
4. Updated the logic to make it only change when the file name actually changes